### PR TITLE
Upgrade to golang 1.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,17 @@
-FROM alpine:3.2
+FROM gliderlabs/alpine:3.3
 ENV GLU_CONTAINER true
+ENV GO_VERSION=1.6
 ENTRYPOINT ["/bin/cat"]
 CMD ["Linux"]
 
 RUN apk --update add curl ca-certificates git mercurial bash && \
     curl -Ls https://circle-artifacts.com/gh/andyshinn/alpine-pkg-glibc/6/artifacts/0/home/ubuntu/alpine-pkg-glibc/packages/x86_64/glibc-2.21-r2.apk > /tmp/glibc-2.21-r2.apk && \
     apk add --allow-untrusted /tmp/glibc-2.21-r2.apk && \
-    curl -Ls https://storage.googleapis.com/golang/go1.5.linux-amd64.tar.gz > /usr/local/go1.5.linux-amd64.tar.gz && \
+    curl -Ls https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz > /usr/local/go${GO_VERSION}.linux-amd64.tar.gz && \
     cd /usr/local && \
-    tar -zxf go1.5.linux-amd64.tar.gz && \
+    tar -zxf go${GO_VERSION}.linux-amd64.tar.gz && \
     ln -s /usr/local/go/bin/go /usr/local/bin/go && \
-    rm -rf /tmp/glibc-2.21-r2.apk /usr/local/go1.5.linux-amd64.tar.gz /var/cache/apk/*
+    rm -rf /tmp/glibc-2.21-r2.apk /usr/local/go${GO_VERSION}.linux-amd64.tar.gz /var/cache/apk/*
 
 COPY ./build /build
 RUN cp /build/Linux/glu /bin/glu \


### PR DESCRIPTION
CircleCi doesn't support golang 1.6 yet, but in a glu container it would be available

For example if sigil would be built with 1.6, than the new `{{-` golang template delimiter could be used
to [trim whitespaces](https://golang.org/pkg/text/template/#hdr-Text_and_spaces)
