### PR TITLE
Replace depricated go build format to avoid warning messages

### DIFF
--- a/build.go
+++ b/build.go
@@ -42,7 +42,7 @@ var buildCmd = &cobra.Command{
 			ldFlag string
 		)
 		if info.Version != "" {
-			ldFlag = fmt.Sprintf("-ldflags \"-X main.Version %s\"", info.Version)
+			ldFlag = fmt.Sprintf("-ldflags \"-X main.Version=%s\"", info.Version)
 		}
 
 		if insideContainer() {


### PR DESCRIPTION
The warning below is printed at each glu build:
    link: warning: option -X main.Version 0.0.5 may not work in future releases; use -X main.Version=0.0.5
